### PR TITLE
Added "Open Source" to Evercam

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ A curated list of companies using Elixir in production, organized by industry.
 #### Video
 
 * [Brightcove](http://brightcove.com) ([GitHub](https://github.com/brightcove)) - A leading global provider of powerful cloud solutions for delivering and monetizing video across connected devices.
-* [Evercam](http://www.evercam.io) ([GitHub](https://github.com/evercam)) - Camera Management Software.
+* [Evercam](http://www.evercam.io) ([GitHub](https://github.com/evercam)) - Camera Management Software (Open Source).
 
 ## Contributing
 


### PR DESCRIPTION
Hi Sean,

Not sure if this is helpful at all, but I added "Open Source" to Evercam as the whole codebase is under AGPL.

Bin it if this doesn't suit you. Nice list :)

Marco