### PR TITLE
Remove Fyber.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ A curated list of companies using Elixir in production, organized by industry.
 * [Meshable](https://meshable.io/trucks) - Ad-Hoc mesh networking to support free WiFi at small businesses.
 
 #### Advertising
-
-* [Fyber](http://www.fyber.com) ([GitHub](https://github.com/SponsorPay)) - Fueling the app economy by creating solutions for smarter ad monetization.
 * [icing](http://geticing.com) - Add an advertisement to any webpage and drive inbound traffic.
 
 #### Consulting


### PR DESCRIPTION
While we are happy to see all the interest and fantastic community around Elixir we are not currently using it in a productive environment; and the position that mentioned Elixir is no longer open. In order to not mislead anyone we ask that the entry for Fyber is removed.