### PR TITLE
Add Planswell.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ We specialize in Ruby on Rails, Ember, Elixir, Phoenix and mobile. We offer cons
 * [Kittysplit](https://kittysplit.com) - A webapp that alows easy splitting of group expenses.
 * [MarketFactory](https://marketfactory.com) ([Github](https://github.com/MarketFactory))- A low-latency FX platform connecting banks/traders to 70+ different FX venues. We leverage elixir/phoenix for multiple back end microservices (ie. trade execution). New York, NY, USA.
 * [Nebo15](http://nebo15.com/) ([Github](https://github.com/Nebo15)) - Large peer-to-peer lending platform completely on Elixir, from scratch. Kiev, Ukraine.
+* [Planswell](https://planswell.com/) ([Github](https://github.com/planswell)) - The company that helps you feel better about your money. Fund your retirement. Send a child to school. Pay off your debts. Planswell shows you how to achieve your biggest goals with one single monthly contribution. Toronto, Canada.
 
 #### Food
 


### PR DESCRIPTION
Add Planswell.com to [Fintech](https://github.com/mariusbutuc/elixir-companies/tree/add-planswell#fintech):

- [x] Company name
- [x] Company description
- [x] Company location
- [x] GitHub link
- [ ] How Elixir is used
- [x] Sorted alphabetically
