### PR TITLE
Remove brutalist.press

### DIFF
--- a/elixir-companies.toml
+++ b/elixir-companies.toml
@@ -257,12 +257,6 @@ github = "https://github.com/briisk"
 description = "Software agency devoted to defining, designing and developing applications, both for web and mobile. We build custom B2B and B2C products with Ruby, Elixir, Angular, Ionic and React Native. Based in Poznan, Poland."
 
 [[company]]
-name = "Brutalist"
-industry = "Media"
-url = "https://brutalist.press"
-description = "The news agency specialized on traditional views."
-
-[[company]]
 name = "CKDU 88.1FM"
 industry = "Radio"
 url = "http://www.ckdu.ca"


### PR DESCRIPTION
brutalist.press propagates hate speech, and I do not think it should be curated here as something to be celebrated. https://brutalist.press/posts/13/who-are-we
