### PR TITLE
fix links

### DIFF
--- a/src/_includes/company-card.html
+++ b/src/_includes/company-card.html
@@ -6,13 +6,13 @@
     <p class="is-size-7">
       <span class="icon purple"><i class="fas fa-fw fa-cogs"></i></span> {{include['company']['industry']}}<br>
     {% if include['company']['url'] %}
-      <span class="icon purple"><i class="fas fa-fw fa-globe"></i></span> <a target="_blank" href="{{include['company']company.www}}">{{include['company']['url'] | replace: "http://", "" | replace: "https://", "" | replace: "www.", ""}}</a><br>
+      <span class="icon purple"><i class="fas fa-fw fa-globe"></i></span> <a target="_blank" href="{{include['company']['url']}}">{{include['company']['url'] | replace: "http://", "" | replace: "https://", "" | replace: "www.", ""}}</a><br>
     {% endif %}
     {% if include['company']['blog'] %}
       <span class="icon purple"><i class="fas fa-fw fa-lightbulb"></i></span> <a target="_blank" href="{{include['company']['blog']}}">{{include['company']['blog'] | replace: "http://", "" | replace: "https://", "" | replace: "www.", ""}}</a><br>
     {% endif %}
     {% if include['company']['github'] %}
-      <span class="icon purple"><i class="fab fa-fw fa-github"></i></span> <a target="_blank" href="https://github.com/{{include['company']['github']}}?language=elixir">GitHub</a><br>
+      <span class="icon purple"><i class="fab fa-fw fa-github"></i></span> <a target="_blank" href="{{include['company']['github']}}?language=elixir">GitHub</a><br>
     {% endif %}
     {% if include['company']['location'] %}
       <span class="icon purple"><i class="fas fa-fw fa-location-arrow"></i></span> {{include['company']['location']}}<br>


### PR DESCRIPTION
The Jekyll template links to the company websites and GitHub accounts aren't working. The company websites appeared to just be a typo.

The GitHub links are broken because the template appears to be expecting a GitHub username. I used the following regex pattern in the company list to verify that all of the :github fields are currently URLs.
```regex
github: ((?!http))
```
It might make sense to convert them all over and display the usernames instead of just `GitHub`. For now though, this should fix the links and that could be done in a separate PR.