### PR TITLE
Official qixxit URL is www.qixxit.com

### DIFF
--- a/src/_data/companies.yml
+++ b/src/_data/companies.yml
@@ -900,7 +900,7 @@ Pypestream:
 
 Qixxit:
   industry: Leisure/Travel
-  url: https://www.qixxit.de
+  url: https://www.qixxit.com
   description: "Qixxit is your personal mobility advisor. We simplify the complexity of mobility for you and combine the many ways of getting from A to B for you in a convenient way. Elixir being used for the backend part. Berlin, Germany"
 
 Quero Education:


### PR DESCRIPTION
Fixing URL only.

Review your changes and complete the checklist below.

- [x] Company name
- [x] Industry
- [x] Company location (in description)
- [x] Company description
- [x] How Elixir is used (in description)
- [ ] GitHub / blog links
- [ ] Job listings
