### PR TITLE
fix dup Marketplace/Marketplaces industry typo

### DIFF
--- a/src/_data/companies.yml
+++ b/src/_data/companies.yml
@@ -1630,7 +1630,7 @@ JoinUp:
   description: "JoinUp is a recruiting chatbot that helps recruiters source & qualify candidates more efficiently on their websites. Our api is powered by Phoenix/Elixir with Reason/React frontends."
 
 Expert360:
-  industry: Marketplace
+  industry: Marketplaces
   url: https://expert360.com
   location: Sydney, Australia
   description: "Expert360 allows businesses to engage and manage top talent for short-mid term project-work. We use Elixir on the backend with Phoenix, Absinthe for our GraphQL API and React components on the frontend."


### PR DESCRIPTION
At the moment there is a `Marketplace` industry, and `Marketplaces` industry listed.

<img width="792" alt="marketplace marketplaces" src="https://user-images.githubusercontent.com/27223/43178998-cae456f8-9013-11e8-8fc0-81dcc3372fc8.png">

Fixed by setting Expert360's industry to `Marketplaces` - which seems to be the convention before it was added.

