### PR TITLE
Update Telnyx's industry

### DIFF
--- a/src/_data/companies.yml
+++ b/src/_data/companies.yml
@@ -1124,7 +1124,7 @@ Teachers Pay Teachers:
       url: "https://boards.greenhouse.io/teacherspayteachers/jobs/1120325"
 
 Telnyx:
-  industry: Communication
+  industry: Telecommunications
   url: https://telnyx.com/
   github: https://github.com/team-telnyx
   description: "Telnyx provides a cloud-based portal & API offering carrier grade voice services such as Origination, Termination and SIPtrunking over the Internet. Chicago, IL, USA."


### PR DESCRIPTION
The "Telecommunications" industry makes more sense for Telnyx than "Communication"; 