### PR TITLE
Remove Planning Center

### DIFF
--- a/src/_data/companies.yml
+++ b/src/_data/companies.yml
@@ -856,12 +856,6 @@ Pivotal:
   github: https://github.com/pivotal
   description: "Leader in software engineering, Pivotal is the company behind CloudFoundry, the Java Spring Framework, and other products. They wrote the new [RabbitMQ CLI](https://github.com/rabbitmq/rabbitmq-cli/) and are [pushing Elixir](http://engineering.pivotal.io/post/elixir-clustering-on-cloud-foundry/) through their engineering blog."
 
-Planning Center:
-  industry: Collaboration
-  url: https://planning.center
-  github: https://github.com/planningcenter
-  description: "Planning Center's suite of apps work together to allow more ministry in your Ministry. Planning Center is from USA. And it's adopting Elixir to it's stack."
-
 Planswell:
   industry: Financial Technology
   url: https://planswell.com/


### PR DESCRIPTION
While we had some internal tools running Elixir and Phoenix in the past, we have yet to push anything to production using them. For that reason, I think it would be better to remove Planning Center from the list for now. I hope I can create another PR that reverses this one at some point in the near future. 🤞 

---

Please review our [Contribution Guidelines](https://github.com/doomspork/elixir-companies/blob/master/CONTRIBUTING.md) to ensure your changes abides by it.

Changes should be made to the __end of the file__.

Review your changes and complete the checklist below.

- [x] Company name
- [x] Industry
- [x] Company location
- [x] Company description
- [x] How Elixir is used
- [x] GitHub / blog links
- [x] Job listings
