### PR TITLE
simple link to show companies per industry

### DIFF
--- a/lib/companies/companies.ex
+++ b/lib/companies/companies.ex
@@ -41,6 +41,12 @@ defmodule Companies.Companies do
     |> order_by([_c, j], desc: j.inserted_at)
   end
 
+  defp predicates(query, %{"industry" => industry_id}) do
+    query
+    |> where([c], c.industry_id == ^industry_id)
+    |> order_by(asc: :name)
+  end
+
   defp predicates(query, _) do
     order_by(query, [c, _i, _j], desc: c.inserted_at)
   end

--- a/lib/companies/industries.ex
+++ b/lib/companies/industries.ex
@@ -17,9 +17,6 @@ defmodule Companies.Industries do
   def all do
     query =
       from i in Industry,
-        join: c in assoc(i, :companies),
-        select: i,
-        distinct: true,
         order_by: i.name
 
     Repo.all(query)

--- a/lib/companies_web/templates/company/card.html.eex
+++ b/lib/companies_web/templates/company/card.html.eex
@@ -8,7 +8,7 @@
   <div class="content company-info has-text-left">
     <p class="is-size-7">
     <span class="icon purple"><i class="fas fa-fw fa-cogs"></i></span>
-    <%= industry_name(@company) %><br>
+    <%= link industry_name(@company), to: Routes.company_path(@conn, :index, industry: @company.industry_id) %><br>
 
     <%= if @company.url do %>
       <span class="icon purple"><i class="fas fa-fw fa-globe"></i></span>


### PR DESCRIPTION
Next step is to add a list of industries and make it possible to browse for each one of them. This is just a simple way to view the other options on a specific industry, by clicking on it in a company card.

I removed most of the query in Industries.all, because it was kinda in the way (if there was not any companies associated with an industry, it would not show, even in the create form).