### PR TITLE
Redirect hiring

### DIFF
--- a/lib/companies_web/controllers/redirect_plug.ex
+++ b/lib/companies_web/controllers/redirect_plug.ex
@@ -1,0 +1,16 @@
+defmodule CompaniesWeb.Redirect do
+  @moduledoc """
+  A plug used to handle redirects by the `CompaniesWeb.Router`
+  """
+  import Plug.Conn
+
+  @spec init(Keyword.t) :: Keyword.t
+  def init(opts), do: opts
+
+  @spec call(Plug.Conn.t, Keyword.t) :: Plug.Conn.t
+  def call(conn, opts) do
+    conn
+    |> Phoenix.Controller.redirect(opts)
+    |> halt()
+  end
+end

--- a/lib/companies_web/controllers/redirect_plug.ex
+++ b/lib/companies_web/controllers/redirect_plug.ex
@@ -4,10 +4,10 @@ defmodule CompaniesWeb.Redirect do
   """
   import Plug.Conn
 
-  @spec init(Keyword.t) :: Keyword.t
+  @spec init(Keyword.t()) :: Keyword.t()
   def init(opts), do: opts
 
-  @spec call(Plug.Conn.t, Keyword.t) :: Plug.Conn.t
+  @spec call(Plug.Conn.t(), Keyword.t()) :: Plug.Conn.t()
   def call(conn, opts) do
     conn
     |> Phoenix.Controller.redirect(opts)

--- a/lib/companies_web/router.ex
+++ b/lib/companies_web/router.ex
@@ -22,7 +22,7 @@ defmodule CompaniesWeb.Router do
     pipe_through :browser
 
     get "/", CompanyController, :recent
-    get "/hiring", CompanyController, :hiring
+    get "/hiring", Redirect, to: "/browse?type=hiring"
     get "/browse", CompanyController, :index
     resources "/users", UserController
   end


### PR DESCRIPTION
 Fixes #476 

Changes Proposed 
- [x] redirect `/hiring` route to `/browse?type=hiring`

Reservations 
Built URL by hand
Didnt build any tests (cheeky)