### PR TITLE
Add support gettext

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -28,7 +28,6 @@ config :companies,
   notifier: Notify.Console,
   site_data: %{
     name: "Elixir Companies",
-    description: "A collection of companies using Elixir in production.",
     maintainers: [
       "doomspork",
       "burden",

--- a/lib/companies_web/helpers/site_helpers.ex
+++ b/lib/companies_web/helpers/site_helpers.ex
@@ -1,12 +1,14 @@
 defmodule CompaniesWeb.SiteHelpers do
   @moduledoc false
 
+  import CompaniesWeb.Gettext
+
   def query_params(%{query_params: %{"type" => type}}), do: [type: type]
   def query_params(_), do: []
 
   def maintainers, do: Map.get(site_data(), :maintainers)
 
-  def site_description, do: Map.get(site_data(), :description)
+  def site_description, do: gettext("A collection of companies using Elixir in production.")
 
   def site_title, do: Map.get(site_data(), :name)
 

--- a/lib/companies_web/templates/company/card.html.eex
+++ b/lib/companies_web/templates/company/card.html.eex
@@ -2,7 +2,7 @@
   <%= if hiring?(@company) do %>
     <div class="ribbon is-warning corner-top-right-ribbon">
       <span>
-        <b>Hiring!</b>
+        <b><%= gettext("Hiring!") %></b>
       </span>
     </div>
   <% end %>
@@ -13,7 +13,7 @@
         <span class="icon purple"><i class="fas fa-edit"></i></span> edit
       <% end %>
       <%= link to: Routes.company_path(@conn, :delete, @company), method: :delete do %>
-        <span class="icon purple"><i class="fas fa-trash-alt"></i></span> delete
+        <span class="icon purple"><i class="fas fa-trash-alt"></i></span> <%= gettext("delete") %>
       <% end %>
     <% end %>
   </div>
@@ -48,7 +48,7 @@
       <span class="icon icon-purle" >
         <i class="fas fa-plus" ></i>
       </span>
-        Add a job
+        <%= gettext("Add a job") %>
       <% end %>
       <br/>
       <%= for job <- @company.jobs do %>

--- a/lib/companies_web/templates/company/edit.html.eex
+++ b/lib/companies_web/templates/company/edit.html.eex
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="columns is-centered">
     <div class="column is-half">
-      <h1 class="has-text-centered title">Edit Company</h1>
+      <h1 class="has-text-centered title"><%= gettext("Edit Company") %></h1>
 
       <%= render "form.html", Map.put(assigns, :action, Routes.company_path(@conn, :update, @company)) %>
 

--- a/lib/companies_web/templates/company/form.html.eex
+++ b/lib/companies_web/templates/company/form.html.eex
@@ -1,12 +1,12 @@
 <%= form_for @changeset, @action, fn f -> %>
   <%= if @changeset.action do %>
     <div class="alert alert-danger">
-      <p>Oops, something went wrong! Please check the errors below.</p>
+      <p><%= gettext("Oops, something went wrong! Please check the errors below.") %></p>
     </div>
   <% end %>
 
   <div class="field">
-    <%= label f, :industry_id, class: "field" %>
+    <%= label f, :industry_id, gettext("Industry"), class: "field" %>
     <div class="control">
       <span class="select">
         <%= select f, :industry_id, select_industries(@industries) %>
@@ -15,7 +15,7 @@
   </div>
 
   <div class="field">
-    <%= label f, :name, class: "field" %>
+    <%= label f, :name, gettext("Name"), class: "field" %>
     <div class="control">
       <%= text_input f, :name, class: "input" %>
       <%= error_tag f, :name %>
@@ -23,7 +23,7 @@
   </div>
 
   <div class="field">
-    <%= label f, :description, class: "field" %>
+    <%= label f, :description, gettext("Description"), class: "field" %>
     <div class="control">
       <%= textarea f, :description, class: "textarea" %>
       <%= error_tag f, :description %>
@@ -31,7 +31,7 @@
   </div>
 
   <div class="field">
-    <%= label f, :url, "Website", class: "field" %>
+    <%= label f, :url, gettext("Website"), class: "field" %>
     <div class="control">
       <%= text_input f, :url, class: "input" %>
       <%= error_tag f, :url %>
@@ -39,7 +39,7 @@
   </div>
 
   <div class="field">
-    <%= label f, :location, class: "field" %>
+    <%= label f, :location, gettext("Location"), class: "field" %>
     <div class="control">
       <%= text_input f, :location, class: "input" %>
       <%= error_tag f, :location %>
@@ -48,7 +48,7 @@
 
   <hr>
 
-  <h5 class="subtitle is-5">Optional fields</h5>
+  <h5 class="subtitle is-5"><%= gettext("Optional fields") %></h5>
 
   <div class="field">
     <%= label f, :github, "GitHub", class: "field" %>
@@ -59,7 +59,7 @@
   </div>
 
   <div class="field">
-    <%= label f, :blog, "Blog website", class: "field" %>
+    <%= label f, :blog, gettext("Blog website"), class: "field" %>
     <div class="control">
       <%= text_input f, :blog, class: "input" %>
       <%= error_tag f, :blog %>
@@ -68,10 +68,10 @@
 
   <div class="field is-grouped is-grouped-centered">
     <div class="control">
-      <%= submit "Save", class: "button is-primary" %>
+      <%= submit gettext("Save"), class: "button is-primary" %>
     </div>
     <div class="control">
-      <%= link "Back", to: Routes.company_path(@conn, :recent), class: "button is-primary" %>
+      <%= link gettext("Back"), to: Routes.company_path(@conn, :recent), class: "button is-primary" %>
     </div>
   </div>
 <% end %>

--- a/lib/companies_web/templates/company/hiring.html.eex
+++ b/lib/companies_web/templates/company/hiring.html.eex
@@ -1,7 +1,7 @@
 <section class="section">
   <div class="container">
     <div class="content">
-      <h1 class="title is-3 fancy">Hiring</h1>
+      <h1 class="title is-3 fancy"><%= gettext("Hiring") %></h1>
       <div class="columns is-desktop is-multiline">
         <%= render CompaniesWeb.CompanyView, "companies.html", companies: @hiring_companies, conn: @conn %>
       </div> <!-- /columns -->

--- a/lib/companies_web/templates/company/index.html.eex
+++ b/lib/companies_web/templates/company/index.html.eex
@@ -1,35 +1,35 @@
 <section class="section">
   <div class="container">
 
-    <h1 class="title is-3 fancy">Browse</h1>
+    <h1 class="title is-3 fancy"><%= gettext("Browse") %></h1>
 
     <div class="tabs is-centered">
       <ul>
         <li>
           <%= link to: Routes.company_path(@conn, :index) do %>
-            Newest
+            <%= gettext("Newest") %>
           <% end %>
-        </li> 
+        </li>
         <li>
           <%= link to: Routes.company_path(@conn, :index, type: "hiring") do %>
-            Hiring 
+            <%= gettext("Hiring") %>
           <% end %>
-        </li> 
+        </li>
         <li>
           <%= link to: Routes.company_path(@conn, :index, type: "ae") do %>
-            A — E 
+            A — E
           <% end %>
-        </li> 
+        </li>
         <li>
           <%= link to: Routes.company_path(@conn, :index, type: "fj") do %>
-            F — J 
+            F — J
           <% end %>
-        </li> 
+        </li>
         <li>
           <%= link to: Routes.company_path(@conn, :index, type: "ko") do %>
             K — O
           <% end %>
-        </li> 
+        </li>
         <li>
           <%= link to: Routes.company_path(@conn, :index, type: "pt") do %>
             P — T
@@ -39,7 +39,7 @@
           <%= link to: Routes.company_path(@conn, :index, type: "uz") do %>
             U — Z
           <% end %>
-        </li> 
+        </li>
       </ul>
     </div>
 

--- a/lib/companies_web/templates/company/new.html.eex
+++ b/lib/companies_web/templates/company/new.html.eex
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="columns is-centered">
     <div class="column is-half">
-      <h1 class="has-text-centered title">New Company</h1>
+      <h1 class="has-text-centered title"><%= gettext("New Company") %></h1>
 
       <%= render "form.html", Map.put(assigns, :action, Routes.company_path(@conn, :create)) %>
 

--- a/lib/companies_web/templates/company/recent.html.eex
+++ b/lib/companies_web/templates/company/recent.html.eex
@@ -6,9 +6,9 @@
           <%= site_description() %>
         </h1>
         <p>
-        With <span class="has-text-weight-semibold">
-          <%= @companies_count %>
-        </span> and counting...</p>
+          <%= raw gettext(
+            "With <span class='has-text-weight-semibold'>%{companies_count}</span> and counting...",
+            companies_count: @companies_count) %>
         <p>
 
         <%= if signed_in?(@conn) do %>
@@ -16,11 +16,11 @@
             <span class="icon">
               <i class="fab fa-github"></i>
             </span>
-            <span class="has-text-weight-semibold">Add a company</span>
+            <span class="has-text-weight-semibold"><%= gettext("Add a company") %></span>
           <% end %>
         <% else %>
           <%= link to: "/auth/github", class: "button is-white is-rounded is-outlined" do %>
-            <span class="has-text-weight-semibold">Sign in & list free</span>
+            <span class="has-text-weight-semibold"><%= gettext("Sign in & list free") %></span>
             <span class="icon">
               <i class="fab fa-github"></i>
             </span>
@@ -34,7 +34,7 @@
 <section class="section">
   <div class="container">
     <div class="content">
-      <h1 class="title is-3 fancy">Recent Additions</h1>
+      <h1 class="title is-3 fancy"><%= gettext("Recent Additions") %></h1>
       <div class="columns is-desktop is-multiline">
         <%= for company <- @recent_companies do %>
           <div class="column is-one-quarter-desktop">

--- a/lib/companies_web/templates/company/show.html.eex
+++ b/lib/companies_web/templates/company/show.html.eex
@@ -1,19 +1,19 @@
-<h1>Show Company</h1>
+<h1><%= gettext("Show Company") %></h1>
 
 <ul>
 
   <li>
-    <strong>Name:</strong>
+    <strong><%= gettext("Name:") %></strong>
     <%= @company.name %>
   </li>
 
   <li>
-    <strong>Description:</strong>
+    <strong><%= gettext("Description:") %></strong>
     <%= @company.description %>
   </li>
 
   <li>
-    <strong>Url:</strong>
+    <strong><%= gettext("Url:") %></strong>
     <%= @company.url %>
   </li>
 
@@ -23,16 +23,16 @@
   </li>
 
   <li>
-    <strong>Location:</strong>
+    <strong><%= gettext("Location:") %></strong>
     <%= @company.location %>
   </li>
 
   <li>
-    <strong>Blog:</strong>
+    <strong><%= gettext("Blog:") %></strong>
     <%= @company.blog %>
   </li>
 
 </ul>
 
-<span><%= link "Edit", to: Routes.company_path(@conn, :edit, @company) %></span>
-<span><%= link "Back", to: Routes.company_path(@conn, :index) %></span>
+<span><%= link gettext("Edit"), to: Routes.company_path(@conn, :edit, @company) %></span>
+<span><%= link gettext("Back"), to: Routes.company_path(@conn, :index) %></span>

--- a/lib/companies_web/templates/error/404_page.html.eex
+++ b/lib/companies_web/templates/error/404_page.html.eex
@@ -1,4 +1,4 @@
 <div class="not_found">
   <div class="not_found-code">404</div>
-  <div class="not_found-text">Looks like you are lost</div>
+  <div class="not_found-text"><%= gettext("Looks like you are lost") %></div>
 </div>

--- a/lib/companies_web/templates/job/edit.html.eex
+++ b/lib/companies_web/templates/job/edit.html.eex
@@ -1,7 +1,7 @@
 <div class="container">
     <div class="columns is-centered">
         <div class="column is-half">
-            <h1 class="title has-text-centered">Edit Job</h1>
+            <h1 class="title has-text-centered"><%= gettext("Edit Job") %></h1>
 
             <%= render "form.html", Map.put(assigns, :action, Routes.job_path(@conn, :update, @job)) %>
         </div>

--- a/lib/companies_web/templates/job/form.html.eex
+++ b/lib/companies_web/templates/job/form.html.eex
@@ -1,12 +1,12 @@
 <%= form_for @changeset, @action, fn f -> %>
   <%= if @changeset.action do %>
     <div class="alert alert-danger">
-      <p>Oops, something went wrong! Please check the errors below.</p>
+      <p><%= gettext("Oops, something went wrong! Please check the errors below.") %></p>
     </div>
   <% end %>
 
   <div class="field">
-      <%= label f, :company_id, class: "field" %>
+      <%= label f, :company_id, gettext("Company"), class: "field" %>
       <div class="control">
           <%= select f, :company_id, companies_for_select(@companies), class: "input" %>
           <%= error_tag f, :company_id %>
@@ -14,7 +14,7 @@
   </div>
 
   <div class="field">
-    <%= label f, :title, class: "field" %>
+    <%= label f, :title, gettext("Title"), class: "field" %>
     <div class="control">
       <%= text_input f, :title, class: "input" %>
       <%= error_tag f, :title %>
@@ -22,7 +22,7 @@
   </div>
 
   <div class="field">
-    <%= label f, :url, class: "field" %>
+    <%= label f, :url, gettext("Url"), class: "field" %>
     <div class="control">
       <%= text_input f, :url, class: "input" %>
       <%= error_tag f, :url %>
@@ -31,10 +31,10 @@
 
   <div class="field is-grouped is-grouped-centered">
     <div class="control">
-      <%= submit "Save", class: "button is-primary" %>
+      <%= submit gettext("Save"), class: "button is-primary" %>
     </div>
     <div class="control">
-      <%= link "Back", to: Routes.company_path(@conn, :recent), class: "button is-primary" %>
+      <%= link gettext("Back"), to: Routes.company_path(@conn, :recent), class: "button is-primary" %>
     </div>
   </div>
 <% end %>

--- a/lib/companies_web/templates/job/new.html.eex
+++ b/lib/companies_web/templates/job/new.html.eex
@@ -1,7 +1,7 @@
 <div class="container">
   <div class="columns is-centered">
     <div class="column is-half">
-      <h1 class="title has-text-centered">New Job</h1>
+      <h1 class="title has-text-centered"><%= gettext("New Job") %></h1>
 
       <%= render "form.html", Map.put(assigns, :action, Routes.job_path(@conn, :create)) %>
     </div>

--- a/lib/companies_web/templates/job/show.html.eex
+++ b/lib/companies_web/templates/job/show.html.eex
@@ -1,18 +1,18 @@
-<h1>Show Job</h1>
+<h1><%= gettext("Show Job") %></h1>
 
 <ul>
 
   <li>
-    <strong>Title:</strong>
+    <strong><%= gettext("Title:") %></strong>
     <%= @job.title %>
   </li>
 
   <li>
-    <strong>Url:</strong>
+    <strong><%= gettext("Url:") %></strong>
     <%= @job.url %>
   </li>
 
 </ul>
 
-<span><%= link "Edit", to: Routes.job_path(@conn, :edit, @job) %></span>
-<span><%= link "Back", to: Routes.job_path(@conn, :index) %></span>
+<span><%= link gettext("Edit"), to: Routes.job_path(@conn, :edit, @job) %></span>
+<span><%= link gettext("Back"), to: Routes.job_path(@conn, :index) %></span>

--- a/lib/companies_web/templates/layout/account.html.eex
+++ b/lib/companies_web/templates/layout/account.html.eex
@@ -3,7 +3,7 @@
     <%= if admin_session?(@conn) do %>
       <p class="control">
       <%= link to: Routes.pending_change_path(@conn, :index), class: "navbar-item is-hidden-#{@version_hidden} button" do %>
-        <span>Approvals</span>
+        <span><%= gettext("Approvals") %></span>
         <span class="icon">
           <i class="fas fa-check-circle"></i>
         </span>
@@ -12,7 +12,7 @@
     <% end %>
     <p class="control">
     <%= link to: Routes.auth_path(@conn, :signout), class: "navbar-item is-hidden-#{@version_hidden} button" do %>
-      <span>Sign out</span>
+      <span><%= gettext("Sign out") %></span>
       <span class="icon">
         <i class="fas fa-sign-out-alt"></i>
       </span>
@@ -21,7 +21,7 @@
   </div>
 <% else %>
   <%= link to: "/auth/github", class: "navbar-item is-hidden-#{@version_hidden} button" do %>
-    <span>Sign in</span>
+    <span><%= gettext("Sign in") %></span>
     <span class="icon">
       <i class="fab fa-github"></i>
     </span>

--- a/lib/companies_web/templates/layout/footer.html.eex
+++ b/lib/companies_web/templates/layout/footer.html.eex
@@ -5,7 +5,7 @@
       <span class="has-text-weight-semibold">
         <%= site_title() %>
       </span>
-      is maintained by
+      <%= gettext("is maintained by") %>
       <%= for maintainer <- maintainers() do %>
         <a class="has-text-weight-semibold" href="https://github.com/<%= maintainer %>">
           @<%= maintainer %>
@@ -13,7 +13,8 @@
       <% end %>
       </p>
       <p>
-      Made possible with support from <a class="has-text-weight-semibold" href="https://utensils.io">utensils.io</a>
+      <%= gettext("Made possible with support from") %>
+      <a class="has-text-weight-semibold" href="https://utensils.io">utensils.io</a>
       </p>
     </div>
   </div>

--- a/lib/companies_web/templates/layout/navbar.html.eex
+++ b/lib/companies_web/templates/layout/navbar.html.eex
@@ -14,9 +14,9 @@
     </div> <!-- /navbarbrand -->
     <div class="navbar-menu" id="navMain">
       <div class="navbar-start">
-        <%= link "Home", to: Routes.company_path(@conn, :recent), class: "navbar-item" %>
-        <%= link "Browse", to: Routes.company_path(@conn, :index), class: "navbar-item" %>
-        <%= link "Hiring", to: Routes.company_path(@conn, :index, type: "hiring"), class: "navbar-item" %>
+        <%= link gettext("Home"), to: Routes.company_path(@conn, :recent), class: "navbar-item" %>
+        <%= link gettext("Browse"), to: Routes.company_path(@conn, :index), class: "navbar-item" %>
+        <%= link gettext("Hiring"), to: Routes.company_path(@conn, :index, type: "hiring"), class: "navbar-item" %>
       </div>
       <div class="navbar-end">
         <%= render "account.html", conn: @conn, version_hidden: "mobile" %>

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1,0 +1,191 @@
+## This file is a PO Template file.
+##
+## `msgid`s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run `mix gettext.extract` to bring this file up to
+## date. Leave `msgstr`s empty as changing them here as no
+## effect: edit them in PO (`.po`) files instead.
+msgid ""
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/recent.html.eex:19
+msgid "Add a company"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/card.html.eex:51
+msgid "Add a job"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/layout/account.html.eex:6
+msgid "Approvals"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/form.html.eex:74
+#: lib/companies_web/templates/company/show.html.eex:38
+#: lib/companies_web/templates/job/form.html.eex:37
+#: lib/companies_web/templates/job/show.html.eex:18
+msgid "Back"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:31
+msgid "Blog:"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/index.html.eex:4
+#: lib/companies_web/templates/layout/navbar.html.eex:18
+msgid "Browse"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:11
+msgid "Description:"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:37
+#: lib/companies_web/templates/job/show.html.eex:17
+msgid "Edit"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/edit.html.eex:4
+msgid "Edit Company"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/job/edit.html.eex:4
+msgid "Edit Job"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/hiring.html.eex:4
+#: lib/companies_web/templates/company/index.html.eex:15
+#: lib/companies_web/templates/layout/navbar.html.eex:19
+msgid "Hiring"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/card.html.eex:5
+msgid "Hiring!"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:26
+msgid "Location:"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/error/404_page.html.eex:3
+msgid "Looks like you are lost"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/layout/footer.html.eex:16
+msgid "Made possible with support from"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:6
+msgid "Name:"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/new.html.eex:4
+msgid "New Company"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/job/new.html.eex:4
+msgid "New Job"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/index.html.eex:10
+msgid "Newest"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/form.html.eex:4
+#: lib/companies_web/templates/job/form.html.eex:4
+msgid "Oops, something went wrong! Please check the errors below."
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/recent.html.eex:37
+msgid "Recent Additions"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/form.html.eex:71
+#: lib/companies_web/templates/job/form.html.eex:34
+msgid "Save"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:1
+msgid "Show Company"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/job/show.html.eex:1
+msgid "Show Job"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/layout/account.html.eex:24
+msgid "Sign in"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/recent.html.eex:23
+msgid "Sign in & list free"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/layout/account.html.eex:15
+msgid "Sign out"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/job/show.html.eex:6
+msgid "Title:"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:16
+#: lib/companies_web/templates/job/show.html.eex:11
+msgid "Url:"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/recent.html.eex:9
+msgid "With <span class='has-text-weight-semibold'>%{companies_count}</span> and counting..."
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/card.html.eex:16
+msgid "delete"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/layout/footer.html.eex:8
+msgid "is maintained by"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/helpers/site_helpers.ex:11
+msgid "A collection of companies using Elixir in production."
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/layout/navbar.html.eex:17
+msgid "Home"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1,0 +1,242 @@
+## `msgid`s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove `msgid`s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2\n"
+
+#, elixir-format
+#: lib/companies_web/templates/company/recent.html.eex:19
+msgid "Add a company"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/card.html.eex:51
+msgid "Add a job"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/layout/account.html.eex:6
+msgid "Approvals"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/form.html.eex:74
+#: lib/companies_web/templates/company/show.html.eex:38
+#: lib/companies_web/templates/job/form.html.eex:37
+#: lib/companies_web/templates/job/show.html.eex:18
+msgid "Back"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:31
+msgid "Blog:"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/index.html.eex:4
+#: lib/companies_web/templates/layout/navbar.html.eex:18
+msgid "Browse"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:11
+msgid "Description:"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:37
+#: lib/companies_web/templates/job/show.html.eex:17
+msgid "Edit"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/edit.html.eex:4
+msgid "Edit Company"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/job/edit.html.eex:4
+msgid "Edit Job"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/hiring.html.eex:4
+#: lib/companies_web/templates/company/index.html.eex:15
+#: lib/companies_web/templates/layout/navbar.html.eex:19
+msgid "Hiring"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/card.html.eex:5
+msgid "Hiring!"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:26
+msgid "Location:"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/error/404_page.html.eex:3
+msgid "Looks like you are lost"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/layout/footer.html.eex:16
+msgid "Made possible with support from"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:6
+msgid "Name:"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/new.html.eex:4
+msgid "New Company"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/job/new.html.eex:4
+msgid "New Job"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/index.html.eex:10
+msgid "Newest"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/form.html.eex:4
+#: lib/companies_web/templates/job/form.html.eex:4
+msgid "Oops, something went wrong! Please check the errors below."
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/recent.html.eex:37
+msgid "Recent Additions"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/form.html.eex:71
+#: lib/companies_web/templates/job/form.html.eex:34
+msgid "Save"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:1
+msgid "Show Company"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/job/show.html.eex:1
+msgid "Show Job"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/layout/account.html.eex:24
+msgid "Sign in"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/recent.html.eex:23
+msgid "Sign in & list free"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/layout/account.html.eex:15
+msgid "Sign out"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/job/show.html.eex:6
+msgid "Title:"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/show.html.eex:16
+#: lib/companies_web/templates/job/show.html.eex:11
+msgid "Url:"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/recent.html.eex:9
+msgid "With <span class='has-text-weight-semibold'>%{companies_count}</span> and counting..."
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/card.html.eex:16
+msgid "delete"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/layout/footer.html.eex:8
+msgid "is maintained by"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/helpers/site_helpers.ex:11
+msgid "A collection of companies using Elixir in production."
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/layout/navbar.html.eex:17
+msgid "Home"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/form.html.eex:62
+msgid "Blog website"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/companies_web/templates/company/form.html.eex:26
+msgid "Description"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/form.html.eex:9
+msgid "Industry"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/companies_web/templates/company/form.html.eex:42
+msgid "Location"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/companies_web/templates/company/form.html.eex:18
+msgid "Name"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/form.html.eex:51
+msgid "Optional fields"
+msgstr ""
+
+#, elixir-format
+#: lib/companies_web/templates/company/form.html.eex:34
+msgid "Website"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/companies_web/templates/job/form.html.eex:9
+msgid "Company"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/companies_web/templates/job/form.html.eex:17
+msgid "Title"
+msgstr ""
+
+#, elixir-format, fuzzy
+#: lib/companies_web/templates/job/form.html.eex:25
+msgid "Url"
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -7,7 +7,6 @@
 ## Run `mix gettext.extract` to bring this file up to
 ## date. Leave `msgstr`s empty as changing them here has no
 ## effect: edit them in PO (`.po`) files instead.
-
 ## From Ecto.Changeset.cast/4
 msgid "can't be blank"
 msgstr ""


### PR DESCRIPTION
Related with #493 

### Notes:

1. Did not add the gettext to the admin area, I think we do not need to translate it. Agree?
2. The project has `resources "/users", UserController` and templates, but does not have ` UserController`. I did not add a gettex to them, it seems they need to be deleted?
3. The list of industries is stored in the database, we need to think about its localization.

Quick sample translations:
![localhost_4000_ (2)](https://user-images.githubusercontent.com/1032291/54103738-9dc14300-43de-11e9-9deb-b2990272fdc2.png)