### PR TITLE
scrollbar brought back for overflowing cards

### DIFF
--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -30,6 +30,7 @@ html {
   background-attachment: fixed, fixed;
   background-image: asset_url("overlay.png"), asset_url("paper_fibers.png");
 
+
   body {
     display: flex;
     min-height: 100vh;
@@ -98,10 +99,36 @@ html {
   }
 
   .box {
+
+
     &.company {
       min-height: 350px;
       max-height: 350px;
       overflow-y: auto;
+
+      background:
+        /* Shadow covers */
+        linear-gradient(white 30%, rgba(255,255,255,0)),
+        linear-gradient(rgba(255,255,255,0), white 70%) 0 100%,
+
+        /* Shadows */
+        radial-gradient(50% 0, farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)),
+        radial-gradient(50% 100%,farthest-side, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
+      background:
+        /* Shadow covers */
+        linear-gradient(white 30%, rgba(255,255,255,0)),
+        linear-gradient(rgba(255,255,255,0), white 70%) 0 100%,
+
+        /* Shadows */
+        radial-gradient(farthest-side at 50% 0, rgba(0,0,0,.2), rgba(0,0,0,0)),
+        radial-gradient(farthest-side at 50% 100%, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%;
+
+      background-repeat: no-repeat;
+      background-color: white;
+      background-size: 100% 40px, 100% 40px, 100% 14px, 100% 14px;
+
+      /* Opera doesn't support this in the shorthand */
+      background-attachment: local, local, scroll, scroll;
 
       .content {
         position: relative;
@@ -164,6 +191,7 @@ html {
     .company-description {
       padding-bottom: 20px;
     }
+
   }
 
   form {

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -101,7 +101,7 @@ html {
     &.company {
       min-height: 350px;
       max-height: 350px;
-      overflow: hidden;
+      overflow-y: auto;
 
       .content {
         position: relative;
@@ -159,6 +159,10 @@ html {
       padding: 10px 0px;
       border-bottom: 1px solid $grey-lighter;
       border-top: 1px solid $grey-lighter;
+    }
+
+    .company-description {
+      padding-bottom: 20px;
     }
   }
 

--- a/assets/css/app.scss
+++ b/assets/css/app.scss
@@ -30,7 +30,6 @@ html {
   background-attachment: fixed, fixed;
   background-image: asset_url("overlay.png"), asset_url("paper_fibers.png");
 
-
   body {
     display: flex;
     min-height: 100vh;
@@ -99,7 +98,6 @@ html {
   }
 
   .box {
-
 
     &.company {
       min-height: 350px;

--- a/lib/companies_web/templates/company/card.html.eex
+++ b/lib/companies_web/templates/company/card.html.eex
@@ -77,7 +77,7 @@
       <% end %>
     </p>
   </div>
-  <div class="content is-size-7 has-text-centered">
+  <div class="content company-description is-size-7 has-text-centered">
     <%= @company.description %>
   </div>
 </div>


### PR DESCRIPTION
At some point we lost the ability to scroll company cards which overflow the cards. This fixes it.
@tajchumber / @burden thoughts on improving this? maybe style a bit the scrollbar?