### PR TITLE
Add the link to browse all companies to bottom the main page

### DIFF
--- a/lib/companies_web/templates/company/recent.html.eex
+++ b/lib/companies_web/templates/company/recent.html.eex
@@ -42,6 +42,9 @@
           </div>
         <% end %>
       </div> <!-- /columns -->
+      <div class="container has-text-centered">
+        <%= link gettext("Browse full list"), to: Routes.company_path(@conn, :index), class: "button is-link" %>
+      </div>
     </div> <!-- /content -->
   </div> <!-- /container -->
 </section>


### PR DESCRIPTION
Small improve main page UX. 
Added additional button to go browse page. This is a logical continuation of viewing the companies list.
Especially convenient on mobile devices. 
<img width="1416" alt="image" src="https://user-images.githubusercontent.com/1032291/55359772-54df4480-54db-11e9-831e-ab5c38bbc2f3.png">
<img width="208" alt="image" src="https://user-images.githubusercontent.com/1032291/55359801-6cb6c880-54db-11e9-88ab-b0b984560289.png">
