### PR TITLE
fix: add configure-pages step to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 20


### PR DESCRIPTION
## Summary

Adds the missing `actions/configure-pages@v4` step to the GitHub Pages deploy workflow. This fixes the 404 error when `actions/deploy-pages@v4` attempts to create a Pages deployment.

The Astro redesign (#827) introduced a new GitHub Actions-based Pages deployment workflow, but omitted the `configure-pages` step that initializes the Pages deployment API. Without it, the deployment endpoint doesn't exist and returns a 404.

## Test Steps

1. Merge this PR to `main`
2. Watch the **Deploy to GitHub Pages** workflow run in [Actions](https://github.com/beam-community/elixir-companies/actions/workflows/deploy.yml)
3. Verify the deploy job succeeds (previously failed with `HttpError: Not Found`)
4. Confirm the site loads at https://elixir-companies.com
5. If deploy still fails with 404, a repo admin should visit [Pages settings](https://github.com/beam-community/elixir-companies/settings/pages) and toggle the Source to reset the configuration

## Checklist

- [x] Build passes locally (`npm run build` — 329 pages)
- [ ] Tests added/updated — N/A (workflow-only change)
- [ ] Documentation updated — N/A