### PR TITLE
feat: add prominent logo to hero section

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -43,6 +43,8 @@ const sortedIndustries = Object.entries(industryCounts)
 
     <div class="relative max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-24 md:py-32">
       <div class="text-center">
+        <img src="/images/elixircompanies_logo.png" alt="Elixir Companies" class="h-40 w-auto mx-auto mb-8" />
+
         <div class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-white/10 backdrop-blur-sm border border-white/20 text-white/90 text-sm font-medium mb-8">
           <span class="w-2 h-2 rounded-full bg-emerald-400 animate-pulse"></span>
           Community-driven & open source


### PR DESCRIPTION
## Summary

Adds the Elixir Companies logo prominently above the "Community-driven & open source" pill in the hero section of the homepage. The logo displays at `h-40` (160px) to serve as a strong brand anchor before the headline text.

## Test Steps

1. Visit the homepage
2. Verify the factory logo appears centered above the "Community-driven & open source" pill
3. Confirm it sits above the "Discover Companies / Powered by Elixir" headline
4. Check the logo scales appropriately on mobile

## Checklist

- [ ] Tests added/updated
- [ ] Documentation updated (if applicable)